### PR TITLE
TST: add coverage to stdout when running the tests and clean up makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ before_install:
   - sudo mv docker-compose /usr/local/bin
 
 script:
-  - make run_tests
+  - make test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,9 @@ services:
       - "80:8000"
     networks:
       - todo_backend
+    # uncomment the two lines below to debug using ipdb
+    #stdin_open: true
+    #tty: true
 
   db:
     image: postgres:9.5

--- a/docker/tests.Dockerfile
+++ b/docker/tests.Dockerfile
@@ -12,8 +12,8 @@ WORKDIR /todo
 
 RUN pip install -r requirements.txt
 
-COPY . /todo 
+COPY . /todo
 
 EXPOSE 80
 
-CMD ["wait-for-it.sh", "db:5432", "--", "pytest"]
+CMD ["wait-for-it.sh", "db:5432", "--", "pytest", "-s", "--cov=todo"]

--- a/makefile
+++ b/makefile
@@ -1,18 +1,23 @@
 build:
-	docker build -t todo:latest -f ./docker/tests.Dockerfile .
+	docker build --tag todo:latest --file ./docker/tests.Dockerfile .
 
 run:
 	cd docker && \
 	docker-compose build && \
 	docker-compose up tests
 
-run_tests:
+test:
 	cd docker && \
 	docker-compose build && \
 	docker-compose up tests
 
+test_debugging_mode:
+	# to debug using pdb/ipdb go in the docker-compose.yml file and uncomment
+	# the stdin and tty lines in the *tests* service
+	cd docker && \
+	docker-compose build && \
+	docker-compose up -d tests
+
 docker_cleanup:
 	cd docker && \
-	docker-compose down -v && \
-	docker rmi -f $(docker images -f dangling=true -q) && \
-	docker images | grep "pattern" | awk '{print $1}' | xargs docker rm
+	docker-compose down --volumes 


### PR DESCRIPTION
Clean up the `makefile`, fixing a bug with the `build` command and creating a new `test_with_dubbing` command for situations when `ipdb` is needed. This last point is not yet fully automated since I need to manually uncomment two lines in the `docker-compose.yml` file.

